### PR TITLE
Remove optional dependency to plugin nvim-lspinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ view all screencasts [here](https://github.com/WhoIsSethDaniel/goldsmith.nvim/wi
 * use the excellent builtin testing framework to run individual tests, package tests, or all your tests
 * all the great Neovim LSP functions are available as Vim commands
 * most commands are completely asynchronous
-* support for [lspinstall](https://github.com/kabouzeid/nvim-lspinstall) and [nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer)
+* support for  [nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer)
 
 # Installation
 Install using your favorite plugin manager. 

--- a/doc/goldsmith.txt
+++ b/doc/goldsmith.txt
@@ -118,7 +118,7 @@ Features currently included:
   tests, or all your tests
 * all the great Neovim LSP functions are available as Vim commands
 * most commands are completely asynchronous
-* support for lspinstall and nvim-lsp-installer
+* support for nvim-lsp-installer
 
 ================================================================================
 SUPPORTED PLUGINS                                  *goldsmith-supported-plugins*
@@ -141,8 +141,6 @@ Optional
 * nvim-treesitter-textobjects
   Needed if you want treesitter textobjects and treesitter navigation. See
   |goldsmith-text-objects|.
-* nvim-lspinstall
-  For installing language servers. i.e. gopls
 * nvim-lsp-installer
   For installing language servers. i.e. gopls
 * null-ls
@@ -2644,7 +2642,6 @@ the plugins that can be utilized by Goldsmith.
 
 * supported plugins:
   `nvim-lspconfig`                https://github.com/neovim/nvim-lspconfig
-  `nvim-lspinstall`               https://github.com/kabouzeid/nvim-lspinstall
   `nvim-lsp-installer`            https://github.com/williamboman/nvim-lsp-installer
   `nvim-treesitter`               https://github.com/nvim-treesitter/nvim-treesitter
   `nvim-treesitter-textobjects`   https://github.com/nvim-treesitter/nvim-treesitter-textobjects

--- a/lua/goldsmith/lsp/servers.lua
+++ b/lua/goldsmith/lsp/servers.lua
@@ -37,18 +37,6 @@ function M.run_setup_function(server, config)
     end
   end
 
-  if plugins.is_installed 'lspinstall' then
-    local installed = require('lspinstall').installed_servers()
-    local sname = M.info(server).lspinstall_name
-    if vim.tbl_contains(installed, sname) then
-      log.debug(sname, function()
-        return 'lspinstall: ' .. vim.inspect(config)
-      end)
-      require('lspconfig')[sname].setup(config)
-      return true
-    end
-  end
-
   if plugins.is_installed 'lspconfig' then
     local sname = M.info(server).lspconfig_name
     log.debug(sname, function()

--- a/lua/goldsmith/tools.lua
+++ b/lua/goldsmith/tools.lua
@@ -168,20 +168,6 @@ local TOOLS = {
       return ok
     end,
   },
-  lspinstall = {
-    name = 'nvim-lspinstall',
-    required = false,
-    installed = false,
-    plugin = true,
-    location = 'https://github.com/kabouzeid/nvim-lspinstall',
-    not_found = {
-      'This plugin may be used to install the LSP servers such as gopls.',
-    },
-    check_installed = function()
-      local ok, _ = pcall(require, 'lspinstall')
-      return ok
-    end,
-  },
   null = {
     name = 'null-ls',
     required = false,
@@ -273,20 +259,6 @@ function M.find_bin(program, info)
 
   if info.server and info['exe'] ~= nil then
     TOOLS[program].installed = false
-    local li_installed = false
-    local li_util
-    if plugins.is_installed 'lspinstall' then
-      local li = require 'lspinstall'
-      li_util = require 'lspinstall.util'
-      li_installed = li.is_server_installed(info.lspinstall_name)
-    end
-    if li_installed then
-      local cmd = string.format('%s/%s', li_util.install_path(info.lspinstall_name), info.exe)
-      if vim.fn.filereadable(cmd) ~= 0 then
-        TOOLS[program].via = 'lspinstall'
-        return cmd
-      end
-    end
     if plugins.is_installed 'lspinstaller' then
       local _, s = require('nvim-lsp-installer').get_server(program)
       local cmd = s._default_options.cmd[1]


### PR DESCRIPTION
Removing optional dependency to plugin 'nvim-lspinstall' as this plugin
has been deprecated in favor of 'nvim-lsp-installer'

resolves #2 