### PR TITLE
fix: Default to utf-16 to satisfy LSP spec

### DIFF
--- a/lua/goldsmith/format.lua
+++ b/lua/goldsmith/format.lua
@@ -46,7 +46,7 @@ function M.organize_imports(wait_ms)
   for client_id, res in pairs(result or {}) do
     for _, r in pairs(res.result or {}) do
       if r.edit then
-        local enc = (vim.lsp.get_client_by_id(client_id) or {}).offset_encoding or 'utf-8'
+        local enc = (vim.lsp.get_client_by_id(client_id) or {}).offset_encoding or 'utf-16'
         vim.lsp.util.apply_workspace_edit(r.edit, enc)
       end
     end


### PR DESCRIPTION
In my previous PR (#56) I assumed `utf-8` to be a safe default in case we fail to obtain the preferred offset encoding from the client. However, I missed the part of the spec that defines `utf-16` as the only mandatory encoding for Text Documents:

> To stay backwards compatible the only mandatory encoding is UTF-16 represented via the string `utf-16`. [...] If the string value `utf-16` is missing from the client’s capability `general.positionEncodings` servers can safely assume that the client supports UTF-16. If the server omits the position encoding in its initialize result the encoding defaults to the string value `utf-16`.
> 
> -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments

This PR sets `utf-16` as the fallback offset encoding instead of `utf-8` to be better aligned with the LSP spec.