### PR TITLE
Speed up startup.

### DIFF
--- a/after/plugin/go.vim
+++ b/after/plugin/go.vim
@@ -1,4 +1,5 @@
 let g:goldsmith_is_setup = v:false
+let g:goldsmith_config_ok = v:false
 if !has('nvim-0.8')
     echohl ErrorMsg
     echomsg 'Goldsmith requires at least neovim 0.8.0.'
@@ -9,8 +10,8 @@ if !has('nvim-0.8')
     finish
 endif
 
-" do the actual configuring for LSP servers and other items that require a late setup/init
-if !luaeval("require'goldsmith'.init()")
+" check the configuration early
+if !luaeval("require'goldsmith'.pre()")
     finish
 endif
-let g:goldsmith_is_setup = v:true
+let g:goldsmith_config_ok = v:true

--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -3,15 +3,15 @@ if exists('g:current_compiler')
 endif
 let g:current_compiler = 'go'
 
-let s:cpo_save = &cpo
-set cpo&vim
+let s:cpo_save = &cpoptions
+set cpoptions&vim
 
 if exists(':CompilerSet') != 2
     command -nargs=* CompilerSet setlocal <args>
 endif
 
-let s:save_cpo = &cpo
-set cpo-=C
+let s:save_cpo = &cpoptions
+set cpoptions-=C
 if filereadable('makefile') || filereadable('Makefile')
     CompilerSet makeprg=make
 else
@@ -26,5 +26,5 @@ CompilerSet errorformat+=%A%\\%%(%[%^:]%\\+:\ %\\)%\\?%f:%l:\ %m
 CompilerSet errorformat+=%C%*\\s%m
 CompilerSet errorformat+=%-G%.%#
 
-let &cpo = s:cpo_save
+let &cpoptions = s:cpo_save
 unlet s:cpo_save

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -3,15 +3,26 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
-let s:cpo_save = &cpo
-set cpo&vim
+let s:cpo_save = &cpoptions
+set cpoptions&vim
 
-if g:goldsmith_is_setup == v:false
+if g:goldsmith_config_ok == v:false
     echohl ErrorMsg
-    echomsg 'Goldsmith: Cannot setup current buffer. Goldsmith failed to initialize.'
+    echomsg 'Goldsmith: Errors with configuration. Goldsmith failed to initialize.'
     echohl None
     echoerr ''
     finish
+endif
+
+if g:goldsmith_is_setup == v:false
+    if !luaeval("require'goldsmith'.init()")
+        echohl ErrorMsg
+        echomsg 'Goldsmith: Failed to initialize'
+        echohl None
+        echoerr ''
+        finish
+    endif
+    let g:goldsmith_is_setup = v:true
 endif
 
 compiler go
@@ -123,5 +134,5 @@ augroup END
 
 lua require'goldsmith.buffer'.setup()
 
-let &cpo = s:cpo_save
+let &cpoptions = s:cpo_save
 unlet s:cpo_save

--- a/ftplugin/gomod.vim
+++ b/ftplugin/gomod.vim
@@ -3,12 +3,26 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
-let s:cpo_save = &cpo
-set cpo&vim
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+if g:goldsmith_config_ok == v:false
+    echohl ErrorMsg
+    echomsg 'Goldsmith: Errors with configuration. Goldsmith failed to initialize.'
+    echohl None
+    echoerr ''
+    finish
+endif
 
 if g:goldsmith_is_setup == v:false
-    echoerr 'Goldsmith: Cannot setup current buffer. Goldsmith failed to initialize.'
-    finish
+    if !luaeval("require'goldsmith'.init()")
+        echohl ErrorMsg
+        echomsg 'Goldsmith: Failed to initialize'
+        echohl None
+        echoerr ''
+        finish
+    endif
+    let g:goldsmith_is_setup = v:true
 endif
 
 setlocal textwidth=0
@@ -50,5 +64,5 @@ augroup END
 
 lua require'goldsmith.buffer'.setup()
 
-let &cpo = s:cpo_save
+let &cpoptions = s:cpo_save
 unlet s:cpo_save

--- a/lua/goldsmith/autoconfig/lsp/null/init.lua
+++ b/lua/goldsmith/autoconfig/lsp/null/init.lua
@@ -56,7 +56,7 @@ function M.is_disabled(service)
   return false
 end
 
-function M.setup(cf)
+function M.setup()
   local null = require 'null-ls'
   local enabled_services = 0
   for _, service in ipairs(M.services()) do
@@ -99,6 +99,11 @@ function M.setup(cf)
       return true
     end
   end
+end
+
+-- basic setup
+function M.pre(cf)
+  local null = require 'null-ls'
   if config.get('null', 'run_setup') then
     null.setup(cf)
   end

--- a/lua/goldsmith/init.lua
+++ b/lua/goldsmith/init.lua
@@ -35,6 +35,7 @@ end
 return {
   config = config.setup,
   setup = ac.register_server,
+  pre = ac.pre,
   init = ac.init,
   needed = ac.needed,
   status = statusline.status,

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -3,8 +3,8 @@ if exists('g:goldsmith_loaded_install')
 endif
 let g:goldsmith_loaded_install = 1
 
-let s:cpo_save = &cpo
-set cpo&vim
+let s:cpo_save = &cpoptions
+set cpoptions&vim
 
 function s:GoInstallComplete(A,C,P) abort
     return luaeval("require'goldsmith.cmds.installbin'.complete(_A[1], _A[2], _A[3])", [a:A, a:C, a:P])
@@ -17,5 +17,5 @@ hi def link goCoverageNormal Comment
 hi def link goCoverageCovered MoreMsg
 hi def link goCoverageNotCovered ErrorMsg
 
-let &cpo = s:cpo_save
+let &cpoptions = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
Split up error checking on LSP startup from
config checking. Only perform LSP error checking
when a go file is loaded. This reduces vim.go
startup time to negligible. goldsmith.lua still takes
some time, but less than it used to.
Will continue to work on goldsmith.lua but I'm reasonably
happy with the results so far.